### PR TITLE
Fix minor CoMEt Exact Test bugs

### DIFF
--- a/weighted_exclusivity_test/exclusivity_tests.py
+++ b/weighted_exclusivity_test/exclusivity_tests.py
@@ -42,6 +42,6 @@ def unweighted_test(t, x, tbl, method=EXACT, tail=ONE_GREATER, verbose=0):
     elif method == EXACT:
         k = len(x)
         assert( tbl and len(tbl) == 2**k )
-        num_tbls, p_value = comet_exact_test( k, N, tbl, 1.1 )
+        p_value, mid_p_value = comet_exact_test( k, N, tbl, 1.1 )
 
     return p_value

--- a/weighted_exclusivity_test/src/c/comet_exact_test.c
+++ b/weighted_exclusivity_test/src/c/comet_exact_test.c
@@ -259,7 +259,7 @@ struct Pvalues comet_exact_test(int k, int N, int *ctbl, double pvalthresh){
                            margins, ex_cells, co_cells, num_co_cells, blank_tbl,
                            mar_stack, 0, T, Tobs);
 
-  p_value     = pval[1];
+  p_value     = pval[0];
   mid_p_value = (pval[0]+pval[1])/2;
   
   // Free memory


### PR DESCRIPTION
Two bugs:
1. Reporting the mid p-value instead of the p-value.
2. Reporting the second term of the mid p-value (Pr[T > T_obs]) rather than the first (Pr[T ≥ T_obs]).
